### PR TITLE
fix: use default export so UMD global works as a constructor

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+Copyright (c) 2017 GitHub, Inc.
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -4,11 +4,10 @@
     <strong>Simple, zero-dependency i18n for static websites.</strong>
   </p>
   <p align="center">
-    Add multi-language support with just a few lines of code — no complex configurations or heavy frameworks needed.
+    Add multi-language support with just a few lines of code, no complex configurations or heavy frameworks needed.
   </p>
   <p align="center">
     <a href="https://www.npmjs.com/package/multilanguagejs"><img src="https://img.shields.io/npm/v/multilanguagejs?style=flat-square&color=cb3837" alt="npm version" /></a>
-    <a href="https://www.npmjs.com/package/multilanguagejs"><img src="https://img.shields.io/npm/dm/multilanguagejs?style=flat-square&color=blue" alt="npm downloads" /></a>
     <a href="https://github.com/ianwelerson/multilanguagejs/blob/main/LICENSE"><img src="https://img.shields.io/npm/l/multilanguagejs?style=flat-square&color=green" alt="license" /></a>
     <a href="https://bundlephobia.com/package/multilanguagejs"><img src="https://img.shields.io/bundlephobia/minzip/multilanguagejs?style=flat-square&color=orange" alt="bundle size" /></a>
   </p>
@@ -18,13 +17,13 @@
 
 ## ✨ Features
 
-- 🚫 **Zero dependencies** — nothing to install besides the lib itself
-- 🔀 **Two translation modes** — HTML templates and string dictionaries
-- 🌐 **Browser language detection** — auto-detect with `navigator.language`
-- 🔄 **Fallback support** — missing translations gracefully fall back to your default language
-- 🔷 **TypeScript** — full type definitions included out of the box
-- 🪶 **Tiny** — ~2KB minified, because your users shouldn't pay for i18n
-- 📦 **CDN + npm** — use it however you want
+- 🚫 **Zero dependencies** - nothing to install besides the lib itself
+- 🔀 **Two translation modes** - HTML templates and string dictionaries
+- 🌐 **Browser language detection** - auto-detect with `navigator.language`
+- 🔄 **Fallback support** - missing translations gracefully fall back to your default language
+- 🔷 **TypeScript** - full type definitions included out of the box
+- 🪶 **Tiny** - ~2KB minified, because your users shouldn't pay for i18n
+- 📦 **CDN + npm** - use it however you want
 
 <br />
 
@@ -39,7 +38,7 @@ npm install multilanguagejs
 ### CDN
 
 ```html
-<script src="https://unpkg.com/multilanguagejs/dist/multilanguagejs.umd.js"></script>
+<script src="https://unpkg.com/multilanguagejs/dist/multilanguagejs.umd.cjs"></script>
 ```
 
 <br />
@@ -48,13 +47,13 @@ npm install multilanguagejs
 
 ### Option 1: String Dictionaries
 
-The simplest approach — provide translations as a JavaScript object and mark elements with `data-i18n`.
+The simplest approach: provide translations as a JavaScript object and mark elements with `data-i18n`.
 
 ```html
 <h1 data-i18n="greeting"></h1>
 <p data-i18n="description"></p>
 
-<script src="https://unpkg.com/multilanguagejs/dist/multilanguagejs.umd.js"></script>
+<script src="https://unpkg.com/multilanguagejs/dist/multilanguagejs.umd.cjs"></script>
 <script>
   const ml = new MultilanguageJS({
     languages: ["en-US", "pt-BR"],
@@ -91,7 +90,7 @@ Use native `<template>` tags to define content variants directly in your HTML.
 </template>
 
 <script type="module">
-  import { MultilanguageJS } from "multilanguagejs";
+  import MultilanguageJS from "multilanguagejs";
 
   const ml = new MultilanguageJS({
     languages: ["en-US", "pt-BR"],
@@ -156,11 +155,8 @@ Creates a new instance.
 Full type definitions are included. Import types directly:
 
 ```ts
-import {
-  MultilanguageJS,
-  type MultilanguageJSOptions,
-  type Translations,
-} from "multilanguagejs";
+import MultilanguageJS from "multilanguagejs";
+import type { MultilanguageJSOptions, Translations } from "multilanguagejs";
 ```
 
 <br />
@@ -179,4 +175,4 @@ npm run lint       # Lint source code
 
 ## 📄 License
 
-MIT — Made with ❤️ by [Ian Welerson](https://github.com/ianwelerson)
+MIT - [Ian Welerson](https://github.com/ianwelerson)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "multilanguagejs",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "multilanguagejs",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "devDependencies": {
         "@testing-library/dom": "^10.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "multilanguagejs",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A simple, zero-dependency i18n library for static websites.",
   "type": "module",
   "main": "dist/multilanguagejs.umd.cjs",

--- a/package.json
+++ b/package.json
@@ -3,14 +3,14 @@
   "version": "2.0.0",
   "description": "A simple, zero-dependency i18n library for static websites.",
   "type": "module",
-  "main": "dist/multilanguagejs.umd.js",
+  "main": "dist/multilanguagejs.umd.cjs",
   "module": "dist/multilanguagejs.es.js",
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/multilanguagejs.es.js",
-      "require": "./dist/multilanguagejs.umd.js"
+      "require": "./dist/multilanguagejs.umd.cjs"
     }
   },
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ export interface MultilanguageJSOptions {
   translations?: Translations
 }
 
-export class MultilanguageJS {
+export default class MultilanguageJS {
   private language: string | null = null
   private defaultLanguage: string | null
   private acceptedLanguages: string[]

--- a/tests/multilanguagejs.test.ts
+++ b/tests/multilanguagejs.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { getByText, queryAllByTestId } from '@testing-library/dom'
-import { MultilanguageJS } from '../src/index'
+import MultilanguageJS from '../src/index'
 import {
   pageWithoutContent,
   pageWithMissingContent,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
       entry: resolve(__dirname, 'src/index.ts'),
       name: 'MultilanguageJS',
       formats: ['es', 'umd'],
-      fileName: (format) => `multilanguagejs.${format}.js`,
+      fileName: (format) => format === 'umd' ? 'multilanguagejs.umd.cjs' : `multilanguagejs.${format}.js`,
     },
     outDir: 'dist',
     sourcemap: true,


### PR DESCRIPTION
The named export caused the UMD build to wrap the class in a namespace
object, so `new MultilanguageJS()` failed with "not a constructor".
Switching to a default export exposes the class directly.

Also renamed the UMD output to .cjs so Node CJS require() works
correctly with the package's "type": "module" setting.

Updated README: fixed import examples, CDN URLs, removed downloads
badge, and minor formatting cleanup.